### PR TITLE
Avoid TypeError when supplying 'bcs = None' if bcs_parameters is also None

### DIFF
--- a/pulse/mechanicsproblem.py
+++ b/pulse/mechanicsproblem.py
@@ -79,7 +79,7 @@ def cardiac_boundary_conditions(
     if geometry.is_biv:
 
         rv_pressure = NeumannBC(
-            traction=Constant(0.0, name="lv_pressure"),
+            traction=Constant(0.0, name="rv_pressure"),
             marker=geometry.markers["ENDO_RV"][0],
             name="rv",
         )

--- a/pulse/mechanicsproblem.py
+++ b/pulse/mechanicsproblem.py
@@ -157,6 +157,8 @@ class MechanicsProblem(object):
         if bcs is None:
             if isinstance(geometry, HeartGeometry):
                 self.bcs_parameters = MechanicsProblem.default_bcs_parameters()
+                if bcs_parameters is not None:
+                    self.bcs_parameters.update(**bcs_parameters)
                 self.bcs_parameters.update(**bcs_parameters)
 
             else:


### PR DESCRIPTION
An easy fix for the TypeError I encountered. Do situations where bcs is None, but bcs_parameters is not None come up? If not, it should just be possible to drop the call to update(**bcs_parameters)?