### PR TITLE
removed parentheses from calls to Fa and eta

### DIFF
--- a/pulse/material/material_model.py
+++ b/pulse/material/material_model.py
@@ -341,7 +341,7 @@ class Material(object):
         I4f = dolfin.variable(self.active.I4(F))
 
         Fe = self.active.Fe(F)
-        Fa = self.active.Fa()
+        Fa = self.active.Fa
         Ce = Fe.T * Fe
 
         # fe = Fe*f0
@@ -381,7 +381,7 @@ class Material(object):
 
         # Active stress
         wactive = self.active.Wactive(F, diff=1)
-        eta = self.active.eta()
+        eta = self.active.eta
 
         S_active = wactive * (f0f0 + eta * (I - f0f0))
 


### PR DESCRIPTION
Fa and eta are properties in the active_stress module and should thus be called without parentheses