### PR TITLE
Improve iteration logger

### DIFF
--- a/pulse/iterate.py
+++ b/pulse/iterate.py
@@ -408,8 +408,11 @@ class Iterator(object):
         self.ncrashes = 0
         self.niters = 0
         logger.info("Iterating....")
-        logger.info(print_control(self.control, "Current control: "))
-        logger.info(print_control(self.target, "Target: "))
+        control_name = delist(self.control).name()
+        msg = f"Current control: {control_name} = "
+        logger.info(print_control(self.control, msg))
+        msg = "Target: "
+        logger.info(print_control(self.target, msg))
         while not self.target_reached():
 
             self.niters += 1

--- a/pulse/iterate.py
+++ b/pulse/iterate.py
@@ -407,8 +407,9 @@ class Iterator(object):
 
         self.ncrashes = 0
         self.niters = 0
-        logger.info("Iterating....")
-        control_name = delist(self.control).name()
+        #print(type(self.control))
+        control_name = self.control[0].name()
+        logger.info(f"Iterating to target control ({control_name})...")
         msg = f"Current control: {control_name} = "
         logger.info(print_control(self.control, msg))
         msg = "Target: "


### PR DESCRIPTION
I added a few lines to write more informative logging statements during iterations. The idea is to extract the name of each control and to include it in the message, to make it clear whether we iterate to, for instance, a target pressure or a material parameter. This information is particularly useful when using pulse as part of pulse_adjoint, since there are typically multiple nested iteration loops.

Since we rely on the "name" for the controls it is required that these are dolfin/fenics functions, which I believe is always the case(?). For the logging info to be useful it also requires users to assign sensible names when creating the functions. This is not always done in the demos, etc., but easy to fix. 

The way the names are extracted is a bit of a hack, but it passes all existing tests and works in the demos. Feel free to improve this or reject the pull request and suggest an improvement.